### PR TITLE
Feat: Work creation script

### DIFF
--- a/script/README.md
+++ b/script/README.md
@@ -1,0 +1,4 @@
+work_creation.py creates an example work 'n' number of times.
+The correct usage is:
+python3 work_creation.py n
+where n is the number of works to be created.

--- a/script/example-work.yaml
+++ b/script/example-work.yaml
@@ -1,0 +1,31 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: Work
+metadata:
+  name: test-work
+  namespace: default
+spec:
+  workload:
+    manifests:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: test-nginx
+        namespace: default
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: test-nginx
+        strategy: {}
+        template:
+          metadata:
+            creationTimestamp: null
+            labels:
+              app: test-nginx
+          spec:
+            containers:
+            - image: nginx:1.14.2
+              name: nginx
+              ports:
+              - containerPort: 80
+              resources: {}

--- a/script/work_creation.py
+++ b/script/work_creation.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+import os
+import random
+import shutil
+import string
+import subprocess
+import sys
+import time
+import yaml
+
+def editWork(y, num):
+    test_name = 'test-work-' + ''.join(random.choices(string.ascii_lowercase, k=10))
+    y['metadata']['name'] = test_name
+    y['spec']['workload']['manifests'][0]['metadata']['name'] = test_name
+
+    modified_name = "modified" + str(num) + ".yaml"
+    with open(modified_name, "w") as output:
+        yaml.dump(y, output, default_flow_style=False, sort_keys=False)
+    return modified_name
+
+def createWork(modified_name):
+    subprocess.run(["kubectl", "apply", "-f", modified_name])
+    os.remove(modified_name)
+    
+def main():
+    with open("example-work.yaml") as f:
+        y = yaml.safe_load(f)
+
+    processes = []
+    batch_size = 50
+    batch_num = int(int(sys.argv[1]) / batch_size)
+    if batch_num > 0:
+        for i in range(0, batch_num - 1):
+            for i in range(0, batch_size):
+                p = multiprocessing.Process(target = createWork, args = (editWork(y, i),))
+                p.start()
+                processes.append(p)
+            for p in processes:
+                p.join()
+
+    for i in range(0, int(sys.argv[1]) % batch_size):
+        p = multiprocessing.Process(target = createWork, args = (editWork(y, i),))
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join()
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
work_creation.py creates an example work 'n' number of times.
The correct usage is:
python3 work_creation.py n
where n is the number of works to be created.

The size of the batch the script uses was chosen after testing different sizes.
Larger sizes may cause "Context deadline" error (timeout).
