### PR TITLE
Feat: Logic reapply manifest

### DIFF
--- a/pkg/controllers/apply_controller.go
+++ b/pkg/controllers/apply_controller.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -202,24 +201,27 @@ func (r *ApplyWorkReconciler) applyUnstructured(
 		return nil, false, err
 	}
 
-	if !findOwnerReference(curObj.GetOwnerReferences(), workObj.GetOwnerReferences()[0]) {
+	if !hasSharedOwnerReference(curObj.GetOwnerReferences(), workObj.GetOwnerReferences()[0]) {
 		// TODO: Block All Owner reference in the Work Manifest.
 		err = fmt.Errorf("this object is not owned by the work-api")
 		klog.V(5).InfoS("This object is not owned by the work-api.", "gvr", gvr, "obj", workObj.GetName(), "err", err)
 		return nil, false, err
 	}
 
-	// Compare and update the unstrcuctured.
-	needUpdate := false
-	if !isSameUnstructuredMeta(workObj, curObj) {
+	// Compare the unstructured object and update if needed.
+	updateWarranted := isUpdateWarranted(workObj, curObj)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if updateWarranted {
 		klog.V(5).InfoS("work object meta has changed", "gvr", gvr, "obj", workObj.GetName())
-		needUpdate = true
 		workObj.SetAnnotations(mergeMapOverrideWithDst(curObj.GetAnnotations(), workObj.GetAnnotations()))
 		workObj.SetLabels(mergeMapOverrideWithDst(curObj.GetLabels(), workObj.GetLabels()))
 		workObj.SetOwnerReferences(mergeOwnerReference(curObj.GetOwnerReferences(), workObj.GetOwnerReferences()))
 	}
 
-	if isManifestModified(observedGeneration, curObj, workObj) || needUpdate {
+	if isManifestModified(observedGeneration, curObj, workObj) || updateWarranted {
 		var actual *unstructured.Unstructured
 		newData, err := workObj.MarshalJSON()
 		if err != nil {
@@ -263,20 +265,29 @@ func isManifestModified(observedGeneration int64, curObj, workObj *unstructured.
 	return false
 }
 
-// isSameUnstructuredMeta compares the metadata of two unstructured object.
-func isSameUnstructuredMeta(obj1, obj2 *unstructured.Unstructured) bool {
-	// we just care about label/annotation and owner references
-	if !equality.Semantic.DeepEqual(obj1.GetLabels(), obj2.GetLabels()) {
-		return false
-	}
-	if !equality.Semantic.DeepEqual(obj1.GetAnnotations(), obj2.GetAnnotations()) {
-		return false
-	}
-	if !equality.Semantic.DeepEqual(obj1.GetOwnerReferences(), obj2.GetOwnerReferences()) {
-		return false
+// Determines if differences between two unstructured.Unstructured objects
+// differ in ways that warrant the update (reapply) of the object.
+func isUpdateWarranted(obj1, obj2 *unstructured.Unstructured) bool {
+	return !isSpecHashAnnotationEqual(obj1, obj2)
+}
+
+// Determines if two annotations (SpecHash) on the two argued objects are equal.
+func isSpecHashAnnotationEqual(obj1 *unstructured.Unstructured, obj2 *unstructured.Unstructured) bool {
+	return obj1.GetAnnotations()[specHashAnnotation] == obj2.GetAnnotations()[specHashAnnotation]
+}
+
+// Generates a hash of the spec annotation from a unstructured object.
+func generateSpecHash(obj *unstructured.Unstructured) (string, error) {
+	data := obj.DeepCopy().Object
+	delete(data, "metadata")
+	delete(data, "status")
+
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
 	}
 
-	return true
+	return fmt.Sprintf("%x", sha256.Sum256(jsonBytes)), nil
 }
 
 // MergeMapOverrideWithDst merges two could be nil maps. Keep the dst for any conflicts,
@@ -295,7 +306,8 @@ func mergeMapOverrideWithDst(src, dst map[string]string) map[string]string {
 	return r
 }
 
-func findOwnerReference(owners []metav1.OwnerReference, target metav1.OwnerReference) bool {
+// Determines if two arrays contain the same metav1.OwnerReference.
+func hasSharedOwnerReference(owners []metav1.OwnerReference, target metav1.OwnerReference) bool {
 	// TODO: Move to a util directory or find an existing library.
 	for _, owner := range owners {
 		if owner.APIVersion == target.APIVersion && owner.Kind == target.Kind && owner.Name == target.Name && owner.UID == target.UID {
@@ -305,14 +317,16 @@ func findOwnerReference(owners []metav1.OwnerReference, target metav1.OwnerRefer
 	return false
 }
 
+// Inserts the owner reference into the array of existing owner references.
 func insertOwnerReference(owners []metav1.OwnerReference, newOwner metav1.OwnerReference) []metav1.OwnerReference {
-	if findOwnerReference(owners, newOwner) {
+	if hasSharedOwnerReference(owners, newOwner) {
 		return owners
 	} else {
 		return append(owners, newOwner)
 	}
 }
 
+// Merges two owner reference arrays.
 func mergeOwnerReference(owners, newOwners []metav1.OwnerReference) []metav1.OwnerReference {
 	for _, newOwner := range newOwners {
 		owners = insertOwnerReference(owners, newOwner)
@@ -365,17 +379,11 @@ func findObservedGenerationOfManifest(
 // setSpecHashAnnotation computes the hash of the provided spec and sets an annotation of the
 // hash on the provided unstructured objectt. This method is used internally by Apply<type> methods.
 func setSpecHashAnnotation(obj *unstructured.Unstructured) error {
-	data := obj.DeepCopy().Object
-	// do not hash metadata and status section
-	delete(data, "metadata")
-	delete(data, "status")
-
-	jsonBytes, err := json.Marshal(data)
+	specHash, err := generateSpecHash(obj)
 	if err != nil {
 		return err
 	}
 
-	specHash := fmt.Sprintf("%x", sha256.Sum256(jsonBytes))
 	annotation := obj.GetAnnotations()
 	if annotation == nil {
 		annotation = map[string]string{}
@@ -385,6 +393,7 @@ func setSpecHashAnnotation(obj *unstructured.Unstructured) error {
 	return nil
 }
 
+// Builds a resource identifier for a given unstructured.Unstructured object.
 func buildResourceIdentifier(index int, object *unstructured.Unstructured, gvr schema.GroupVersionResource) workv1alpha1.ResourceIdentifier {
 	identifier := workv1alpha1.ResourceIdentifier{
 		Ordinal: index,


### PR DESCRIPTION
### Description of your changes

Modified the reapply logic to only consider if a manifest needs to be reapplied if the spec hash annotation has changed.

I have:

- [x] Read and followed Caravel's [Code of conduct](https://github.com/Azure/k8s-work-api/blob/master/code-of-conduct.md).
- [x] Run `make reviewable` to ensure this PR is ready for review.

